### PR TITLE
Terence/dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 .vscode
 
 compute_fp_1
+proj

--- a/README.md
+++ b/README.md
@@ -8,5 +8,5 @@ Terence Cheung
 ## How to run:
 ```
 make all
-./proj /path/to/file/compute_fp_1
+./proj /path/to/file/compute_fp_1 10 10 2
 ```

--- a/makefile
+++ b/makefile
@@ -1,5 +1,3 @@
-## This is a simple Makefile 
-
 # Define what compiler to use and the flags.
 CC=cc
 CXX=g++
@@ -20,11 +18,8 @@ pipeline_stage.o: pipeline_stage.cpp trace.h
 file_input.o: file_input.cpp trace.h
 trace.o: trace.cpp trace.h
 
-###################################
-# BEGIN SOLUTION
 proj: proj.o file_input.o trace.o pipeline_simulator.o pipeline_stage.o
 	$(CXX) -o proj proj.o file_input.o trace.o pipeline_simulator.o pipeline_stage.o $(CCFLAGS) $(LDLIBS)
-
 
 clean:
 	rm -f core *.o proj

--- a/pipeline_simulator.cpp
+++ b/pipeline_simulator.cpp
@@ -15,27 +15,56 @@ PipelineSimulator::~PipelineSimulator()
     // cleanup
 }
 
-void PipelineSimulator::runSimulation(const std::string &file_name, long start_inst, long inst_count, int pipelineWidth)
+void PipelineSimulator::runSimulation(const std::string &file_name, unsigned long start_inst, unsigned long inst_count, int pipeline_width)
 {
     FileInput file;
 
     file.ReadTraceFromFile(file_name);
     std::set<unsigned long> completed_instructions;
-    long executed = 0;
+
+    unsigned long executed = 0;
     while (executed < start_inst) {
         Trace tmp = file.GetNext();
         completed_instructions.insert(tmp.instructionAddr);
+
         executed++;
     }
-    executed = 0;
-    printf("%ld\n", completed_instructions.size());
-    // while (executed < inst_count) {
-    //     Trace next_instr = file.GetNext();
-    //     if (!next_instr.isValid()) {
-    //         return;
-    //     }
-    //     completed_instructions.erase(next_instr.instructionAddr);
-    //     // do something with the instruction
-    //     executed++;
-    // }
+
+    // TODO: probably need a set for when something is done ex and for mem
+    // "For dependence on integer or FP instructions, dependences are satisfied when they complete EX"
+    //"For dependence on load or store instructions, dependences are satisfied when they complete MEM"
+
+    IFStage IF_stage;
+    IDStage ID_stage;
+    EXStage EX_stage;
+    MEMStage MEM_stage;
+    WBStage WB_stage;
+    while (this->currentCycle < inst_count) {
+        Trace* finished_IF = new Trace[pipeline_width];
+        // process IF
+        for (int i = 0; i < pipeline_width; i++) {
+            Trace next_instr = file.GetNext();
+            if (!next_instr.isValid()) {
+                return;
+            }
+            completed_instructions.erase(next_instr.instructionAddr);
+            IF_stage.insert(next_instr);
+            finished_IF[i] = IF_stage.process();
+        }
+        // process ID
+        Trace* finished_ID = new Trace[pipeline_width];
+        for (int i = 0; i < pipeline_width; i++) {
+            finished_ID[i] = ID_stage.process();
+        }
+        // add finished IFs to ID
+        for (int i = 0; i < pipeline_width; i++) {
+            if (finished_IF[i].isValid()) {
+                ID_stage.insert(finished_IF[i]);
+            }
+        }
+        
+        delete[] finished_IF;
+        delete[] finished_ID;
+        this->currentCycle++;
+    }
 }

--- a/pipeline_simulator.h
+++ b/pipeline_simulator.h
@@ -11,7 +11,7 @@ class PipelineSimulator
 {
 private:
     // stage array
-    unsigned long currentCycle = 0;
+    unsigned long currentCycle;
 
 public:
     PipelineSimulator();

--- a/pipeline_simulator.h
+++ b/pipeline_simulator.h
@@ -11,13 +11,13 @@ class PipelineSimulator
 {
 private:
     // stage array
-    unsigned long currentCycle;
+    unsigned long currentCycle = 0;
 
 public:
     PipelineSimulator();
     ~PipelineSimulator();
 
-    void runSimulation(const std::string &tfile_name, long start_inst, long inst_count, int pipelineWidth);
+    void runSimulation(const std::string &tfile_name, unsigned long start_inst, unsigned long inst_count, int pipeline_width);
 };
 
 #endif

--- a/pipeline_stage.cpp
+++ b/pipeline_stage.cpp
@@ -1,8 +1,19 @@
 #include "pipeline_stage.h"
 
-void PipelineStage::process(const Trace &instruction)
+void PipelineStage::insert(const Trace &instruction)
 {
     instructions.push_back(instruction);
+}
+
+Trace PipelineStage::process()
+{
+    // returns and removes first item from list deque
+    Trace res;
+    if (!instructions.empty()) {
+        res = instructions.front();
+        instructions.erase(instructions.begin());
+    }
+    return res;
 }
 
 bool PipelineStage::isEmpty() const
@@ -10,9 +21,14 @@ bool PipelineStage::isEmpty() const
     return instructions.empty();
 }
 
-void IFStage::process(const Trace &instruction)
+void IFStage::insert(const Trace &instruction)
 {
-    PipelineStage::process(instruction);
+    PipelineStage::insert(instruction);
+}
+
+Trace IFStage::process()
+{
+    return PipelineStage::process();
 }
 
 bool IFStage::isEmpty() const
@@ -20,9 +36,14 @@ bool IFStage::isEmpty() const
     return PipelineStage::isEmpty();
 }
 
-void IDStage::process(const Trace &instruction)
+void IDStage::insert(const Trace &instruction)
 {
-    PipelineStage::process(instruction);
+    PipelineStage::insert(instruction);
+}
+
+Trace IDStage::process()
+{
+    return PipelineStage::process();
 }
 
 bool IDStage::isEmpty() const
@@ -30,9 +51,14 @@ bool IDStage::isEmpty() const
     return PipelineStage::isEmpty();
 }
 
-void EXStage::process(const Trace &instruction)
+void EXStage::insert(const Trace &instruction)
 {
-    PipelineStage::process(instruction);
+    PipelineStage::insert(instruction);
+}
+
+Trace EXStage::process()
+{
+    return PipelineStage::process();
 }
 
 bool EXStage::isEmpty() const
@@ -40,9 +66,14 @@ bool EXStage::isEmpty() const
     return PipelineStage::isEmpty();
 }
 
-void MEMStage::process(const Trace &instruction)
+void MEMStage::insert(const Trace &instruction)
 {
-    PipelineStage::process(instruction);
+    PipelineStage::insert(instruction);
+}
+
+Trace MEMStage::process()
+{
+    return PipelineStage::process();
 }
 
 bool MEMStage::isEmpty() const
@@ -50,9 +81,14 @@ bool MEMStage::isEmpty() const
     return PipelineStage::isEmpty();
 }
 
-void WBStage::process(const Trace &instruction)
+void WBStage::insert(const Trace &instruction)
 {
-    PipelineStage::process(instruction);
+    PipelineStage::insert(instruction);
+}
+
+Trace WBStage::process()
+{
+    return PipelineStage::process();
 }
 
 bool WBStage::isEmpty() const

--- a/pipeline_stage.h
+++ b/pipeline_stage.h
@@ -1,16 +1,17 @@
 #ifndef PIPELINE_STAGE_H_
 #define PIPELINE_STAGE_H_
 
-#include <vector>
+#include <deque>
 #include "trace.h"
 
 class PipelineStage
 {
 public:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
     // insert, remove implementation
-    virtual void process(const Trace &instruction) = 0;
+    virtual void insert(const Trace &instruction) = 0;
+    virtual Trace process() = 0;
     virtual bool isEmpty() const = 0;
     virtual ~PipelineStage() {}
 };
@@ -19,10 +20,11 @@ public:
 class IFStage : public PipelineStage
 {
 private:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
 public:
-    void process(const Trace &instruction) override;
+    void insert(const Trace &instruction) override;
+    Trace process() override;
     bool isEmpty() const override;
 };
 
@@ -30,10 +32,11 @@ public:
 class IDStage : public PipelineStage
 {
 private:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
 public:
-    void process(const Trace &instruction) override;
+    void insert(const Trace &instruction) override;
+    Trace process() override;
     bool isEmpty() const override;
 };
 
@@ -41,10 +44,11 @@ public:
 class EXStage : public PipelineStage
 {
 private:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
 public:
-    void process(const Trace &instruction) override;
+    void insert(const Trace &instruction) override;
+    Trace process() override;
     bool isEmpty() const override;
 };
 
@@ -52,10 +56,11 @@ public:
 class MEMStage : public PipelineStage
 {
 private:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
 public:
-    void process(const Trace &instruction) override;
+    void insert(const Trace &instruction) override;
+    Trace process() override;
     bool isEmpty() const override;
 };
 
@@ -63,10 +68,11 @@ public:
 class WBStage : public PipelineStage
 {
 private:
-    std::vector<Trace> instructions;
+    std::deque<Trace> instructions;
 
 public:
-    void process(const Trace &instruction) override;
+    void insert(const Trace &instruction) override;
+    Trace process() override;
     bool isEmpty() const override;
 };
 

--- a/proj.cpp
+++ b/proj.cpp
@@ -12,9 +12,10 @@ int main(int argc, char *argv[]) {
         printf("Not enough arguments\n");
         return 0;
     }
+
     std::string file_name = argv[1];
-    long start_inst = std::stol(argv[2]);
-    long inst_count = std::stol(argv[3]);
+    unsigned long start_inst = std::stoul(argv[2]);
+    unsigned long inst_count = std::stoul(argv[3]);
     int width = std::stoi(argv[4]);
 
     PipelineSimulator simulation;


### PR DESCRIPTION
- old process is now insert in pipeline_stage
- instructions uses a deque instead of vector because:
    - can pop from front
    - can still access elements in order and remove from middle, when the first instruction cant be executed.
